### PR TITLE
ユーザのデータ構造変更

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -16,6 +16,8 @@ exports.onCreateUser = functions
       if (!userDoc.exists) {
         await t.set(userRef, {
           displayId: '',
+          name: user.displayName || '',
+          photoUrl: user.photoURL || '',
           type: '',
           statusTags: [],
           copy: '',

--- a/src/pages/user/edit.vue
+++ b/src/pages/user/edit.vue
@@ -4,7 +4,7 @@
       <PageTitle>プロフィール編集</PageTitle>
     </div>
     <div class="form">
-      <UserEditForm :original-data="userData" :photo-url="photoUrl" />
+      <UserEditForm :original-data="userData" :photo-url="userData.photoUrl" />
     </div>
   </div>
 </template>
@@ -27,14 +27,8 @@ export default {
     return {
       userData: {
         ...userDocSnapshot.data(),
-        name: context.$currentUser.get().displayName,
       },
     }
-  },
-  computed: {
-    photoUrl() {
-      return this.$currentUser.get().photoUrl
-    },
   },
 }
 </script>

--- a/src/plugins/auth.js
+++ b/src/plugins/auth.js
@@ -7,8 +7,6 @@ const authPlugin = (context, inject) => {
     if (user) {
       state.currentUser = {
         id: user.uid,
-        displayName: user.displayName,
-        photoUrl: user.photoURL,
       }
     } else {
       state.currentUser = null


### PR DESCRIPTION
# 実装内容
firestoreのuserコレクションのデータ構造を変更。
（ユーザーネームと、画像URLをドキュメントに持たせるように）

上記に合わせて、データの参照先や持ち方を変更する。